### PR TITLE
Bump Guzzle for Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "guzzlehttp/guzzle": "~6.0|~5.0|~4.0",
+        "guzzlehttp/guzzle": "~7.0|~6.0|~5.0|~4.0",
         "ext-mbstring": "*"
     },
     "require-dev": {


### PR DESCRIPTION
Quick bump of the Guzzle constraint so your downstream Laravel package is compatible with Laravel 8 - which requires Guzzle 7.